### PR TITLE
Sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ There is a rake task for this as well -
 ```
 rake new_page["Title of Page"]
 ```
+Set `page.sitemap.include` to `'yes'`, to include the page in sitemap.
+```
+sitemap:
+  include: 'yes'
+```
 
 
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -4,6 +4,8 @@ short_title: About
 title: About Coding Blocks
 permalink: /about/
 feature-img: "img/code_banner.png"
+sitemap:
+  include: 'yes'
 ---
 
 **Coding Blocks** is a Software Development Bootcamp located in New Delhi.

--- a/pages/categories.html
+++ b/pages/categories.html
@@ -5,7 +5,8 @@ permalink: /categories/index.html
 title: Categories
 tags: [Categories]
 description: "An archive of posts sorted by categories."
-
+siteamp:
+  include: 'yes'
 ---
 
 <ul class="tag-box inline">

--- a/rakefile
+++ b/rakefile
@@ -39,6 +39,8 @@ end
      post.puts "chart: "
      post.puts "comments: true"
      post.puts "featured: false"
+     post.puts "sitemap:"
+     post.puts "  include: "
      post.puts "---"
    end
   end

--- a/rakefile
+++ b/rakefile
@@ -39,8 +39,6 @@ end
      post.puts "chart: "
      post.puts "comments: true"
      post.puts "featured: false"
-     post.puts "sitemap:"
-     post.puts "  include: "
      post.puts "---"
    end
   end
@@ -67,6 +65,8 @@ end
      post.puts "chart: "
      post.puts "comments: true"
      post.puts "author: "
+     post.puts "sitemap:"
+     post.puts "  include: "
      post.puts "---"
    end
 end

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,48 @@
+---
+layout: null
+sitemap:
+  exclude: 'yes'
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for post in site.posts %}
+    {% unless post.published == false %}
+    <url>
+      <loc>{{ site.url }}{{ post.url }}</loc>
+      {% if post.sitemap.lastmod %}
+        <lastmod>{{ post.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
+      {% elsif post.date %}
+        <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+      {% else %}
+        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+      {% endif %}
+      {% if post.sitemap.changefreq %}
+        <changefreq>{{ post.sitemap.changefreq }}</changefreq>
+      {% else %}
+        <changefreq>monthly</changefreq>
+      {% endif %}
+        <priority>0.5</priority>
+    </url>
+    {% endunless %}
+  {% endfor %}
+  {% for page in site.pages %}
+    {% unless page.sitemap.exclude == "yes" %}
+    <url>
+      <loc>{{ site.url }}{{ page.url | remove: "index.html" }}</loc>
+      {% if page.sitemap.lastmod %}
+        <lastmod>{{ page.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
+      {% elsif page.date %}
+        <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>
+      {% else %}
+        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+      {% endif %}
+      {% if page.sitemap.changefreq %}
+        <changefreq>{{ page.sitemap.changefreq }}</changefreq>
+      {% else %}
+        <changefreq>monthly</changefreq>
+      {% endif %}
+        <priority>0.3</priority>
+    </url>
+    {% endunless %}
+  {% endfor %}
+</urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,7 +1,5 @@
 ---
 layout: null
-sitemap:
-  exclude: 'yes'
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -26,7 +24,7 @@ sitemap:
     {% endunless %}
   {% endfor %}
   {% for page in site.pages %}
-    {% unless page.sitemap.include == "yes" %}
+    {% if page.sitemap.include == "yes" %}
     <url>
       <loc>{{ site.url }}{{ page.url | remove: "index.html" }}</loc>
       {% if page.sitemap.lastmod %}
@@ -43,6 +41,6 @@ sitemap:
       {% endif %}
         <priority>0.3</priority>
     </url>
-    {% endunless %}
+    {% endif %}
   {% endfor %}
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -26,7 +26,7 @@ sitemap:
     {% endunless %}
   {% endfor %}
   {% for page in site.pages %}
-    {% unless page.sitemap.exclude == "yes" %}
+    {% unless page.sitemap.include == "yes" %}
     <url>
       <loc>{{ site.url }}{{ page.url | remove: "index.html" }}</loc>
       {% if page.sitemap.lastmod %}


### PR DESCRIPTION
Added a fully functioning sitemap without any plugin. 

Updated rakefile to include `page.sitemap.include`. All posts will be included automatically. 

To include a certain page in sitemap, set `page.sitemap.include` to `’yes’`.

Added the details to readme too.